### PR TITLE
Xcode support

### DIFF
--- a/src/open_bedrock_server/adapters/bedrock_to_openai_adapter.py
+++ b/src/open_bedrock_server/adapters/bedrock_to_openai_adapter.py
@@ -31,10 +31,20 @@ class BedrockToOpenAIAdapter(BaseLLMAdapter):
     def __init__(self, openai_model_id: str, **kwargs):
         super().__init__(openai_model_id, **kwargs)
         self.openai_model_id = openai_model_id
-        self.openai_adapter = OpenAIAdapter(model_id=openai_model_id, **kwargs)
+        self._openai_adapter = None
+        self._openai_adapter_kwargs = kwargs
         logger.info(
             f"BedrockToOpenAIAdapter initialized for OpenAI model: {self.openai_model_id}"
         )
+
+    @property
+    def openai_adapter(self) -> OpenAIAdapter:
+        """Lazily initialize OpenAIAdapter only when needed for API calls."""
+        if self._openai_adapter is None:
+            self._openai_adapter = OpenAIAdapter(
+                model_id=self.openai_model_id, **self._openai_adapter_kwargs
+            )
+        return self._openai_adapter
 
     def convert_bedrock_to_openai_request(
         self, bedrock_request: BedrockClaudeRequest | BedrockTitanRequest

--- a/src/open_bedrock_server/api/routes/chat.py
+++ b/src/open_bedrock_server/api/routes/chat.py
@@ -371,6 +371,8 @@ async def unified_chat_completions(
                         else:  # Yield OpenAI chunk
                             yield f"data: {json.dumps(chunk.model_dump(exclude_none=True))}\n\n"
 
+                    yield "data: [DONE]\n\n"
+
                 except HTTPException:
                     raise
                 except Exception as e_stream:

--- a/src/open_bedrock_server/api/routes/models.py
+++ b/src/open_bedrock_server/api/routes/models.py
@@ -44,21 +44,23 @@ async def list_models_route():  # Renamed to avoid conflict with imported list_m
     except Exception as e:
         logger.error(f"Error listing models from OpenAI: {e}")
 
-    # Placeholder for Bedrock models (when BedrockService is implemented)
-    # try:
-    #     bedrock_service = LLMServiceFactory.get_service("bedrock")
-    #     if hasattr(bedrock_service, 'list_models') and callable(bedrock_service.list_models):
-    #         bedrock_models = await bedrock_service.list_models()
-    #         all_models.extend(bedrock_models)
-    #         logger.info(f"Successfully fetched {len(bedrock_models)} models from Bedrock.")
-    #     else:
-    #         logger.warning("Bedrock service from factory does not have a callable list_models method.")
-    # except NotImplementedError:
-    #     logger.info("Bedrock service not yet implemented, skipping model listing for Bedrock.")
-    # except ValueError as e:
-    #     logger.warning(f"Could not get Bedrock service from factory: {e}")
-    # except Exception as e:
-    #     logger.error(f"Error listing models from Bedrock: {e}")
+    # Bedrock models (when BedrockService is implemented)
+    try:
+        bedrock_service = LLMServiceFactory.get_service("bedrock")
+        if hasattr(bedrock_service, "list_models") and callable(
+            bedrock_service.list_models
+        ):
+            bedrock_models = await bedrock_service.list_models()
+            all_provider_models.extend(bedrock_models)
+            logger.info(f"Fetched {len(bedrock_models)} models from Bedrock.")
+        else:
+            logger.warning("Bedrock service does not have a callable list_models method.")
+    except NotImplementedError:
+        logger.info("Bedrock service list_models not yet implemented, skipping.")
+    except ValueError as e:
+        logger.warning(f"Could not get Bedrock service from factory: {e}")
+    except Exception as e:
+        logger.error(f"Error listing models from Bedrock: {e}")
 
     # Map List[ModelProviderInfo] to List[ModelInfo] for the response
     api_model_list: list[ModelInfo] = []


### PR DESCRIPTION
Enables Open Bedrock for use as a model provider in Xcode via Intelligence [settings](https://developer.apple.com/documentation/Xcode/setting-up-coding-intelligence#Use-another-provider)