### PR TITLE
feat: add pr-review skill for PR lifecycle workflow

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -25,7 +25,7 @@ Branch naming conventions:
 | Type | Pattern | Example |
 | --- | --- | --- |
 | Bug fix | `fix/<short-desc>` | `fix/streaming-error-handling` |
-| Feature | `feat/<short-desc>` | `feat/persistent-history` |
+| Feature | `feature/<short-desc>` | `feature/persistent-history` |
 | Docs | `docs/<short-desc>` | `docs/event-system-refresh` |
 
 ## Step 1b — Check for existing PRs on the branch
@@ -103,14 +103,14 @@ sleep 300
 After the initial wait, poll every 2 minutes until comments appear:
 
 ```bash
-bash ~/.claude/skills/pr-review/scripts/pr-comments.sh <PR_NUMBER>
+bash .claude/skills/pr-review/scripts/pr-comments.sh <PR_NUMBER>
 ```
 
 If no comments yet, wait and retry:
 
 ```bash
 sleep 120
-bash ~/.claude/skills/pr-review/scripts/pr-comments.sh <PR_NUMBER>
+bash .claude/skills/pr-review/scripts/pr-comments.sh <PR_NUMBER>
 ```
 
 Continue until at least one unresolved comment exists, or 3 consecutive polls
@@ -155,16 +155,17 @@ Guidelines:
 Use batch mode to reply to all comments at once:
 
 ```bash
-bash ~/.claude/skills/pr-review/scripts/pr-batch.sh --resolve <PR_NUMBER> <<'EOF'
+bash .claude/skills/pr-review/scripts/pr-batch.sh --resolve <PR_NUMBER> <<'EOF'
 {"comment_id": 123, "body": "Fixed -- changed X to Y.\n\n- Claude"}
-{"comment_id": 456, "body": "Intentional -- this follows the pattern in Z because...\n\n- Claude"}
+{"comment_id": 456, "body": "Intentional -- follows pattern in Z.\n\n- Claude"}
 EOF
 ```
 
 Or reply to a single comment:
 
 ```bash
-bash ~/.claude/skills/pr-review/scripts/pr-reply.sh --resolve <PR_NUMBER> <COMMENT_ID> "Fixed -- updated.\n\n- Claude"
+bash .claude/skills/pr-review/scripts/pr-reply.sh \
+  --resolve <PR_NUMBER> <COMMENT_ID> "Fixed -- updated.\n\n- Claude"
 ```
 
 **Important:**
@@ -201,9 +202,10 @@ git add <files> && git commit -m "message"
 git push -u origin docs/my-change
 gh pr create --title "..." --body "..."
 sleep 300
-bash ~/.claude/skills/pr-review/scripts/pr-comments.sh <PR>
+bash .claude/skills/pr-review/scripts/pr-comments.sh <PR>
 # ... enter plan mode, triage, get approval ...
 # ... fix issues, commit, push ...
-bash ~/.claude/skills/pr-review/scripts/pr-batch.sh --resolve <PR> <<< '{"comment_id":N,"body":"Fixed\n\n- Claude"}'
+bash .claude/skills/pr-review/scripts/pr-batch.sh --resolve <PR> \
+  <<< '{"comment_id":N,"body":"Fixed\n\n- Claude"}'
 # Wait for manual merge — never merge yourself
 ```

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: pr-review
+description: >
+  Full PR workflow for open-bedrock-server: branch, commit, push, create PR,
+  wait for automated reviewers, fetch comments, fix or pushback, reply, resolve
+  threads. Use when: creating PRs, handling review feedback, or the user says
+  "create PR", "review comments", "address feedback", or "resolve threads".
+---
+
+# PR Review Workflow
+
+Complete pull request lifecycle for the open-bedrock-server project. Follow
+every step in order.
+
+## Step 1 — Branch
+
+If you are on `main`, create a feature branch first:
+
+```bash
+git checkout -b <branch-name>
+```
+
+Branch naming conventions:
+
+| Type | Pattern | Example |
+| --- | --- | --- |
+| Bug fix | `fix/<short-desc>` | `fix/streaming-error-handling` |
+| Feature | `feat/<short-desc>` | `feat/persistent-history` |
+| Docs | `docs/<short-desc>` | `docs/event-system-refresh` |
+
+## Step 1b — Check for existing PRs on the branch
+
+Before adding new work to an existing branch, check if there's already an
+open PR:
+
+```bash
+gh pr view --json number,title,state --jq '{number,title,state}'
+```
+
+If the command fails with "no pull requests found", there is no open PR —
+proceed normally. Only act on the result if it returns valid JSON with
+`state: "OPEN"`.
+
+If an open PR exists and your new changes are **unrelated** to that PR's
+scope, **stop and ask the user**:
+
+> "There's an open PR (#N: 'title') on this branch. The new changes
+> are unrelated to that PR. Would you like to merge the existing PR
+> first before starting the new work?"
+
+Wait for the user's answer before proceeding.
+
+## Step 2 — Make changes, commit, push
+
+1. Edit code
+2. Run tests: `uv run python run_tests.py --mode all-safe -v`
+3. Run lint: `flake8 src/ && black --check src/ tests/ && isort --check src/ tests/`
+4. Stage and commit:
+
+   ```bash
+   git add <files>
+   git commit -m "$(cat <<'EOF'
+   Commit message here.
+
+   Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+   EOF
+   )"
+   ```
+
+5. Push:
+
+   ```bash
+   git push -u origin <branch-name>
+   ```
+
+## Step 3 — Create PR
+
+```bash
+gh pr create --title "Short title" --body "$(cat <<'EOF'
+## Summary
+- Bullet points describing changes
+
+## Test plan
+- [ ] Test items
+
+- Claude
+EOF
+)"
+```
+
+## Step 4 — Wait for reviewers
+
+Automated reviewers (Qodo, Copilot) need time to post comments.
+
+**Wait 5 minutes** after creating the PR before checking for comments:
+
+```bash
+sleep 300
+```
+
+## Step 5 — Poll for comments
+
+After the initial wait, poll every 2 minutes until comments appear:
+
+```bash
+bash ~/.claude/skills/pr-review/scripts/pr-comments.sh <PR_NUMBER>
+```
+
+If no comments yet, wait and retry:
+
+```bash
+sleep 120
+bash ~/.claude/skills/pr-review/scripts/pr-comments.sh <PR_NUMBER>
+```
+
+Continue until at least one unresolved comment exists, or 3 consecutive polls
+return zero comments (reviewers are done / not configured).
+
+## Step 6 — Triage each comment
+
+**Enter plan mode** to present a triage table to the user before making changes.
+
+For every review comment, decide:
+
+- **FIX** — valid concern, make the code change
+- **PUSHBACK** — disagree, explain why in the reply
+
+Present as a table:
+
+| # | File | Issue | Decision | Reason |
+| --- | --- | --- | --- | --- |
+| 1 | `file.py` | Missing null check | FIX | Valid edge case |
+| 2 | `other.py` | Rename variable | PUSHBACK | Matches project convention |
+
+Guidelines:
+
+- Exception type mismatches are always valid
+- Test requests are always valid — add them
+- Style nits are usually valid — fix them
+- Architecture opinions may warrant pushback if they conflict with project
+  conventions (check `CLAUDE.md` and `docs/`)
+
+**Wait for user approval** before proceeding to fixes.
+
+## Step 7 — Fix code and push
+
+1. Make all code fixes
+2. Run tests: `uv run python run_tests.py --mode all-safe -v`
+3. Run lint: `flake8 src/ && black --check src/ tests/ && isort --check src/ tests/`
+4. Commit with a descriptive message
+5. Push: `git push`
+
+## Step 8 — Reply and resolve threads
+
+Use batch mode to reply to all comments at once:
+
+```bash
+bash ~/.claude/skills/pr-review/scripts/pr-batch.sh --resolve <PR_NUMBER> <<'EOF'
+{"comment_id": 123, "body": "Fixed -- changed X to Y.\n\n- Claude"}
+{"comment_id": 456, "body": "Intentional -- this follows the pattern in Z because...\n\n- Claude"}
+EOF
+```
+
+Or reply to a single comment:
+
+```bash
+bash ~/.claude/skills/pr-review/scripts/pr-reply.sh --resolve <PR_NUMBER> <COMMENT_ID> "Fixed -- updated.\n\n- Claude"
+```
+
+**Important:**
+
+- Always sign replies with `\n\n- Claude`
+- Always use `--resolve` to resolve the thread after replying
+- Every comment must get a reply — no silent fixes
+
+## Step 9 — Wait for merge
+
+**Never merge the PR yourself.** The PR is merged manually on the GitHub site.
+
+Report to the user that all review threads are addressed and the PR is ready
+for merge.
+
+## Script reference
+
+| Script | Purpose |
+| --- | --- |
+| `pr-comments.sh <PR>` | Fetch all review comments |
+| `pr-reply.sh [--resolve] <PR> <ID> "body"` | Reply to one comment |
+| `pr-batch.sh [--resolve] <PR> < jsonl` | Batch reply from JSONL stdin |
+
+All scripts auto-detect `owner/repo` from the current git remote.
+
+## Quick reference — full flow
+
+```text
+git checkout -b docs/my-change
+# ... make changes ...
+uv run python run_tests.py --mode all-safe -v
+flake8 src/ && black --check src/ tests/ && isort --check src/ tests/
+git add <files> && git commit -m "message"
+git push -u origin docs/my-change
+gh pr create --title "..." --body "..."
+sleep 300
+bash ~/.claude/skills/pr-review/scripts/pr-comments.sh <PR>
+# ... enter plan mode, triage, get approval ...
+# ... fix issues, commit, push ...
+bash ~/.claude/skills/pr-review/scripts/pr-batch.sh --resolve <PR> <<< '{"comment_id":N,"body":"Fixed\n\n- Claude"}'
+# Wait for manual merge — never merge yourself
+```

--- a/.claude/skills/pr-review/scripts/pr-batch.sh
+++ b/.claude/skills/pr-review/scripts/pr-batch.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Batch reply to PR review comments from JSONL on stdin.
+# Each line: {"comment_id": 123, "body": "reply text"}
+# Usage: pr-batch.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER < input.jsonl
+
+REPO=""
+RESOLVE=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        --resolve) RESOLVE=true; shift ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-batch.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER < input.jsonl}"
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVE_FLAG=""
+if [[ "$RESOLVE" == true ]]; then
+    RESOLVE_FLAG="--resolve"
+fi
+
+SUCCESS=0
+FAIL=0
+
+while IFS= read -r line; do
+    # Skip empty lines
+    [[ -z "$line" ]] && continue
+
+    COMMENT_ID=$(echo "$line" | jq -r '.comment_id')
+    BODY=$(echo "$line" | jq -r '.body')
+
+    if [[ "$COMMENT_ID" == "null" || "$BODY" == "null" ]]; then
+        echo "SKIP: invalid line: $line"
+        ((FAIL++)) || true
+        continue
+    fi
+
+    echo "--- Comment $COMMENT_ID ---"
+    if bash "$SCRIPT_DIR/pr-reply.sh" --repo "$REPO" $RESOLVE_FLAG "$PR_NUMBER" "$COMMENT_ID" "$BODY"; then
+        ((SUCCESS++)) || true
+    else
+        echo "FAILED: comment $COMMENT_ID"
+        ((FAIL++)) || true
+    fi
+done
+
+echo ""
+echo "Done: $SUCCESS succeeded, $FAIL failed"

--- a/.claude/skills/pr-review/scripts/pr-comments.sh
+++ b/.claude/skills/pr-review/scripts/pr-comments.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fetch and display all review comments on a PR.
+# Usage: pr-comments.sh [--repo OWNER/REPO] PR_NUMBER
+
+REPO=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-comments.sh [--repo OWNER/REPO] PR_NUMBER}"
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+
+# Fetch thread resolution status via GraphQL
+THREADS_JSON=$(gh api graphql -f query="
+{
+  repository(owner: \"${REPO%%/*}\", name: \"${REPO##*/}\") {
+    pullRequest(number: $PR_NUMBER) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          comments(first: 1) {
+            nodes { databaseId }
+          }
+        }
+      }
+    }
+  }
+}" --jq '.data.repository.pullRequest.reviewThreads.nodes')
+
+# Build a map of comment_id -> {thread_id, resolved}
+THREAD_MAP=$(echo "$THREADS_JSON" | jq -r '
+  [.[] | {
+    comment_id: .comments.nodes[0].databaseId,
+    thread_id: .id,
+    resolved: .isResolved
+  }]
+')
+
+# Fetch all review comments via REST
+COMMENTS=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments" --paginate)
+
+# Display formatted output
+echo "$COMMENTS" | jq -r --argjson threads "$THREAD_MAP" '
+  .[] | . as $c |
+  ($threads | map(select(.comment_id == $c.id)) | first // {resolved: "unknown", thread_id: "?"}) as $t |
+  "──────────────────────────────────────────────────",
+  "ID: \($c.id)  |  Thread: \(if $t.resolved == true then "RESOLVED" elif $t.resolved == false then "UNRESOLVED" else "?" end)  |  Reply-to: \($c.in_reply_to_id // "none")",
+  "File: \($c.path):\($c.original_line // $c.line // "?")",
+  "Thread ID: \($t.thread_id)",
+  "",
+  ($c.body | split("\n") | if length > 10 then .[:10] + ["... (truncated)"] else . end | join("\n")),
+  ""
+'

--- a/.claude/skills/pr-review/scripts/pr-reply.sh
+++ b/.claude/skills/pr-review/scripts/pr-reply.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reply to a PR review comment, optionally resolve its thread.
+# Usage: pr-reply.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER COMMENT_ID "body"
+
+REPO=""
+RESOLVE=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        --resolve) RESOLVE=true; shift ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-reply.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER COMMENT_ID \"body\"}"
+COMMENT_ID="${2:?Missing COMMENT_ID}"
+BODY="${3:?Missing reply body}"
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+
+# Append signature
+BODY="${BODY}
+
+- Claude"
+
+# Post reply
+REPLY_URL=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments/$COMMENT_ID/replies" \
+    -f body="$BODY" \
+    --jq '.html_url')
+echo "Replied: $REPLY_URL"
+
+# Resolve thread if requested
+if [[ "$RESOLVE" == true ]]; then
+    # Find the thread ID for this comment
+    THREAD_ID=$(gh api graphql -f query="
+    {
+      repository(owner: \"${REPO%%/*}\", name: \"${REPO##*/}\") {
+        pullRequest(number: $PR_NUMBER) {
+          reviewThreads(first: 100) {
+            nodes {
+              id
+              comments(first: 1) {
+                nodes { databaseId }
+              }
+            }
+          }
+        }
+      }
+    }" --jq ".data.repository.pullRequest.reviewThreads.nodes[] | select(.comments.nodes[0].databaseId == $COMMENT_ID) | .id")
+
+    if [[ -n "$THREAD_ID" ]]; then
+        RESOLVED=$(gh api graphql -f query="
+          mutation { resolveReviewThread(input: {threadId: \"$THREAD_ID\"}) { thread { isResolved } } }
+        " --jq '.data.resolveReviewThread.thread.isResolved')
+        echo "Resolved: $RESOLVED (thread $THREAD_ID)"
+    else
+        echo "Warning: could not find thread for comment $COMMENT_ID"
+    fi
+fi


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/pr-review/SKILL.md` — a complete PR lifecycle workflow skill (branch, commit, push, create PR, wait for reviewers, triage comments, fix/pushback, reply, resolve threads)
- Copied from open-responses-server and adapted for this project's tooling: `uv run python run_tests.py`, `black`/`isort`/`flake8` linting

## Test plan
- [ ] Verify skill is discoverable by Claude Code in this repo
- [ ] Walk through the workflow on a future PR to validate steps

- Claude