### PR TITLE
docs: migrate to just-the-docs with anthropic cream theme

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,25 +32,29 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: '3.3'
           bundler-cache: true
           cache-version: 0
           working-directory: docs
-      
+
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v4
-      
+        uses: actions/configure-pages@v5
+
+      - name: Initialize search index
+        run: bundle exec just-the-docs rake search:init
+        working-directory: docs
+
       - name: Build with Jekyll
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         working-directory: docs
         env:
           JEKYLL_ENV: production
-      
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
@@ -66,4 +70,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4 
+        uses: actions/deploy-pages@v4

--- a/docs/FILES_API.md
+++ b/docs/FILES_API.md
@@ -1,3 +1,9 @@
+---
+title: Files API
+nav_order: 9
+description: File upload, management, and chat integration API
+---
+
 # Files API Documentation
 
 ## Overview

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,25 +1,6 @@
 source "https://rubygems.org"
 
-# GitHub Pages gem
-gem "github-pages", group: :jekyll_plugins
-
-# Jekyll plugins
-group :jekyll_plugins do
-  gem "jekyll-feed"
-  gem "jekyll-sitemap"
-  gem "jekyll-seo-tag"
-end
-
-# Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
-# and associated library.
-platforms :mingw, :x64_mingw, :mswin, :jruby do
-  gem "tzinfo", ">= 1", "< 3"
-  gem "tzinfo-data"
-end
-
-# Performance-booster for watching directories on Windows
-gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
-
-# Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
-# do not have a Java counterpart.
-gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby] 
+gem "jekyll", "~> 4.3"
+gem "just-the-docs", "~> 0.10"
+gem "jekyll-seo-tag"
+gem "jekyll-relative-links"

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
 gem "jekyll", "~> 4.3"
-gem "just-the-docs", "~> 0.10"
+gem "just-the-docs", "~> 0.12"
 gem "jekyll-seo-tag"
 gem "jekyll-relative-links"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,0 +1,250 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.9)
+      public_suffix (>= 2.0.2, < 8.0)
+    base64 (0.3.0)
+    bigdecimal (4.1.0)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.6)
+    csv (3.3.5)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.17.4)
+    ffi (1.17.4-aarch64-linux-gnu)
+    ffi (1.17.4-aarch64-linux-musl)
+    ffi (1.17.4-arm-linux-gnu)
+    ffi (1.17.4-arm-linux-musl)
+    ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x86-linux-gnu)
+    ffi (1.17.4-x86-linux-musl)
+    ffi (1.17.4-x86_64-darwin)
+    ffi (1.17.4-x86_64-linux-gnu)
+    ffi (1.17.4-x86_64-linux-musl)
+    forwardable-extended (2.6.0)
+    google-protobuf (4.34.1)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-aarch64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-aarch64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-arm64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86_64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86_64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    http_parser.rb (0.8.1)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.4.1)
+      addressable (~> 2.4)
+      base64 (~> 0.2)
+      colorator (~> 1.0)
+      csv (~> 3.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      json (~> 2.6)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (~> 0.3, >= 0.3.6)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-include-cache (0.2.1)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-relative-links (0.7.0)
+      jekyll (>= 3.3, < 5.0)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
+    jekyll-seo-tag (2.8.0)
+      jekyll (>= 3.8, < 5.0)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    json (2.19.3)
+    just-the-docs (0.12.0)
+      jekyll (>= 3.8.5)
+      jekyll-include-cache
+      jekyll-seo-tag (>= 2.0)
+      rake (>= 12.3.1)
+    kramdown (2.5.2)
+      rexml (>= 3.4.4)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.10.0)
+      logger
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
+    mercenary (0.4.0)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (7.0.5)
+    rake (13.3.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.4.4)
+    rouge (4.7.0)
+    safe_yaml (1.0.5)
+    sass-embedded (1.98.0)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sass-embedded (1.98.0-aarch64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.98.0-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.98.0-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.98.0-arm-linux-androideabi)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.98.0-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.98.0-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.98.0-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.98.0-riscv64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.98.0-riscv64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.98.0-riscv64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.98.0-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.98.0-x86_64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.98.0-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.98.0-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.6.0)
+    webrick (1.9.2)
+
+PLATFORMS
+  aarch64-linux-android
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-androideabi
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
+  arm64-darwin
+  riscv64-linux-android
+  riscv64-linux-gnu
+  riscv64-linux-musl
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-android
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  jekyll (~> 4.3)
+  jekyll-relative-links
+  jekyll-seo-tag
+  just-the-docs (~> 0.10)
+
+CHECKSUMS
+  addressable (2.8.9) sha256=cc154fcbe689711808a43601dee7b980238ce54368d23e127421753e46895485
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  bigdecimal (4.1.0) sha256=6dc07767aa3dc456ccd48e7ae70a07b474e9afd7c5bc576f80bd6da5c8dd6cae
+  colorator (1.1.0) sha256=e2f85daf57af47d740db2a32191d1bdfb0f6503a0dfbc8327d0c9154d5ddfc38
+  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
+  csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
+  em-websocket (0.5.3) sha256=f56a92bde4e6cb879256d58ee31f124181f68f8887bd14d53d5d9a292758c6a8
+  eventmachine (1.2.7) sha256=994016e42aa041477ba9cff45cbe50de2047f25dd418eba003e84f0d16560972
+  ffi (1.17.4) sha256=bcd1642e06f0d16fc9e09ac6d49c3a7298b9789bcb58127302f934e437d60acf
+  ffi (1.17.4-aarch64-linux-gnu) sha256=b208f06f91ffd8f5e1193da3cae3d2ccfc27fc36fba577baf698d26d91c080df
+  ffi (1.17.4-aarch64-linux-musl) sha256=9286b7a615f2676245283aef0a0a3b475ae3aae2bb5448baace630bb77b91f39
+  ffi (1.17.4-arm-linux-gnu) sha256=d6dbddf7cb77bf955411af5f187a65b8cd378cb003c15c05697f5feee1cb1564
+  ffi (1.17.4-arm-linux-musl) sha256=9d4838ded0465bef6e2426935f6bcc93134b6616785a84ffd2a3d82bc3cf6f95
+  ffi (1.17.4-arm64-darwin) sha256=19071aaf1419251b0a46852abf960e77330a3b334d13a4ab51d58b31a937001b
+  ffi (1.17.4-x86-linux-gnu) sha256=38e150df5f4ca555e25beca4090823ae09657bceded154e3c52f8631c1ed72cf
+  ffi (1.17.4-x86-linux-musl) sha256=fbeec0fc7c795bcf86f623bb18d31ea1820f7bd580e1703a3d3740d527437809
+  ffi (1.17.4-x86_64-darwin) sha256=aa70390523cf3235096cf64962b709b4cfbd5c082a2cb2ae714eb0fe2ccda496
+  ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
+  ffi (1.17.4-x86_64-linux-musl) sha256=3fdf9888483de005f8ef8d1cf2d3b20d86626af206cbf780f6a6a12439a9c49e
+  forwardable-extended (2.6.0) sha256=1bec948c469bbddfadeb3bd90eb8c85f6e627a412a3e852acfd7eaedbac3ec97
+  google-protobuf (4.34.1) sha256=347181542b8d659c60f028fa3791c9cccce651a91ad27782dbc5c5e374796cdc
+  google-protobuf (4.34.1-aarch64-linux-gnu) sha256=f9c07607dc139c895f2792a7740fcd01cd94d4d7b0e0a939045b50d7999f0b1d
+  google-protobuf (4.34.1-aarch64-linux-musl) sha256=db58e5a4a492b43c6614486aea31b7fb86955b175d1d48f28ebf388f058d78a9
+  google-protobuf (4.34.1-arm64-darwin) sha256=2745061f973119e6e7f3c81a0c77025d291a3caa6585a2cd24a25bbc7bedb267
+  google-protobuf (4.34.1-x86-linux-gnu) sha256=b6da7891fe96b13038e5435d8ac8b8a84d78a468147a48a377fe8da40aba1c88
+  google-protobuf (4.34.1-x86-linux-musl) sha256=ea0f453e78f4c30d0d9dbaa8cf9b33d2a1ea04ab2cad2c2a07e479411c05f1a9
+  google-protobuf (4.34.1-x86_64-darwin) sha256=4dc498376e218871613589c4d872400d42ad9ae0c700bdb2606fe1c77a593075
+  google-protobuf (4.34.1-x86_64-linux-gnu) sha256=87088c9fd8e47b5b40ca498fc1195add6149e941ff7e81c532a5b0b8876d4cc9
+  google-protobuf (4.34.1-x86_64-linux-musl) sha256=8c0e91436fbe504ffc64f0bd621f2e69adbcce8ed2c58439d7a21117069cfdd7
+  http_parser.rb (0.8.1) sha256=9ae8df145b39aa5398b2f90090d651c67bd8e2ebfe4507c966579f641e11097a
+  i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
+  jekyll (4.4.1) sha256=4c1144d857a5b2b80d45b8cf5138289579a9f8136aadfa6dd684b31fe2bc18c1
+  jekyll-include-cache (0.2.1) sha256=c7d4b9e551732a27442cb2ce853ba36a2f69c66603694b8c1184c99ab1a1a205
+  jekyll-relative-links (0.7.0) sha256=831e54c348eeae751845c0d4ac4b244bd73b664341f0e8c9f1803b16f4570835
+  jekyll-sass-converter (3.1.0) sha256=83925d84f1d134410c11d0c6643b0093e82e3a3cf127e90757a85294a3862443
+  jekyll-seo-tag (2.8.0) sha256=3f2ed1916d56f14ebfa38e24acde9b7c946df70cb183af2cb5f0598f21ae6818
+  jekyll-watch (2.2.1) sha256=bc44ed43f5e0a552836245a54dbff3ea7421ecc2856707e8a1ee203a8387a7e1
+  json (2.19.3) sha256=289b0bb53052a1fa8c34ab33cc750b659ba14a5c45f3fcf4b18762dc67c78646
+  just-the-docs (0.12.0) sha256=15f2839ac9082898d60f33b978aa6f8e46fc50ba8fac20ae7a7f0e1fb295523e
+  kramdown (2.5.2) sha256=1ba542204c66b6f9111ff00dcc26075b95b220b07f2905d8261740c82f7f02fa
+  kramdown-parser-gfm (1.1.0) sha256=fb39745516427d2988543bf01fc4cf0ab1149476382393e0e9c48592f6581729
+  liquid (4.0.4) sha256=4fcfebb1a045e47918388dbb7a0925e7c3893e58d2bd6c3b3c73ec17a2d8fdb3
+  listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  mercenary (0.4.0) sha256=b25a1e4a59adca88665e08e24acf0af30da5b5d859f7d8f38fba52c28f405138
+  pathutil (0.16.2) sha256=e43b74365631cab4f6d5e4228f812927efc9cb2c71e62976edcb252ee948d589
+  public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
+  rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
+  rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rouge (4.7.0) sha256=dba5896715c0325c362e895460a6d350803dbf6427454f49a47500f3193ea739
+  safe_yaml (1.0.5) sha256=a6ac2d64b7eb027bdeeca1851fe7e7af0d668e133e8a88066a0c6f7087d9f848
+  sass-embedded (1.98.0) sha256=397dcd0071170f079eb97562a035fa113358af10e3ff759a57bc7eef763e9f94
+  sass-embedded (1.98.0-aarch64-linux-android) sha256=bdc2c0e7473f569e53342adb7d7abc9349083bd8181e053a356218063ae09a32
+  sass-embedded (1.98.0-aarch64-linux-gnu) sha256=019baa4ee850f9d6f3f53125fd4ee56b13ea5191bc8f8f9436825ec3e171b02d
+  sass-embedded (1.98.0-aarch64-linux-musl) sha256=9f4defd3cddf0bbf129f0b6ad8af966bdb90e36ab162f49a5b9f1baaf3339af1
+  sass-embedded (1.98.0-arm-linux-androideabi) sha256=eb3346f36ce6c378821bc422f0edda03cef03208e47b2a9d8e62330ed08e1361
+  sass-embedded (1.98.0-arm-linux-gnueabihf) sha256=763277f4070caccd6fcbcf4c54249539effe78c36850617922834a8eb72177d7
+  sass-embedded (1.98.0-arm-linux-musleabihf) sha256=7e21e46569f5cc47d5d04d77c73e4bdb08547304e2ed0ff6b9a83d608c0d9a2b
+  sass-embedded (1.98.0-arm64-darwin) sha256=fed4ee6de2f30b14e7a678ca648730aa78acc86be7a555e16ba3fdbc5e6aca69
+  sass-embedded (1.98.0-riscv64-linux-android) sha256=6fee03d351e6eb3ffe3168702a3b045e56f7e4d435c98368e6e5ccb621eefbae
+  sass-embedded (1.98.0-riscv64-linux-gnu) sha256=5ca86012b061d63f1e37a7afab507b619f0928554d2cae126b259a093c2530b0
+  sass-embedded (1.98.0-riscv64-linux-musl) sha256=a28c0ec5318b515999e0db03a1e4eca54ff77c35b81df453ebe335c053ae6b30
+  sass-embedded (1.98.0-x86_64-darwin) sha256=a0b5b64f0157e2f1d713ac5ea75474c8507c464f0923090094471c33d4244484
+  sass-embedded (1.98.0-x86_64-linux-android) sha256=830e2c120001bdd5e2dea29e2b803c3c1481bfacc7d93cf676f63c4454f06b2b
+  sass-embedded (1.98.0-x86_64-linux-gnu) sha256=36b72021e00cfdd91ccb9eb490cff6addc376424cf9c2786f01392c8d0f0d4a0
+  sass-embedded (1.98.0-x86_64-linux-musl) sha256=8f66a2db9bb1efd95df340e4157be3803be8b22b5f2f5280d9387553fcb9584a
+  terminal-table (3.0.2) sha256=f951b6af5f3e00203fb290a669e0a85c5dd5b051b3b023392ccfd67ba5abae91
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
+  webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
+
+BUNDLED WITH
+  4.0.7

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,70 +1,50 @@
-# Jekyll configuration for GitHub Pages
 title: Open Bedrock Server
-description: A unified, provider-agnostic chat completions API server supporting OpenAI and AWS Bedrock
-url: "https://teabranch.github.io"
+description: >-
+  A unified, provider-agnostic chat completions API server supporting OpenAI and AWS Bedrock.
 baseurl: "/open-bedrock-server"
-repository: teabranch/open-bedrock-server
-# Theme
-theme: minima
-remote_theme: pages-themes/minimal@v0.2.0
+url: "https://teabranch.github.io"
+
+theme: just-the-docs
+color_scheme: anthropic
+
+search_enabled: true
+search:
+  button: true
+
+aux_links:
+  "GitHub":
+    - "https://github.com/teabranch/open-bedrock-server"
+aux_links_new_tab: true
+
+footer_content: >-
+  Open Bedrock Server — Licensed under
+  <a href="https://github.com/teabranch/open-bedrock-server/blob/main/LICENSE">MIT</a>.
 
 webmaster_verifications:
   google: SAWMasZ1hKCZm8hnk0xFUgqnFYYPgdrKG8jKuTJa6a0
-  
-# Plugins
-plugins:
-  - jekyll-feed
-  - jekyll-sitemap
-  - jekyll-seo-tag
 
-# Markdown settings
+plugins:
+  - jekyll-seo-tag
+  - jekyll-relative-links
+
+relative_links:
+  enabled: true
+  collections: false
+
 markdown: kramdown
 kramdown:
   input: GFM
   syntax_highlighter: rouge
-  syntax_highlighter_opts:
-    css_class: 'highlight'
 
-# Collections
-collections:
-  guides:
-    output: true
-    permalink: /:collection/:name/
-
-# Navigation
-header_pages:
-  - index.md
-  - getting-started.md
-  - api-reference.md
-  - guides/index.md
-  - cli-reference.md
-  - development.md
-
-# Defaults
 defaults:
   - scope:
       path: ""
-      type: "pages"
-    values:
-      layout: "default"
-  - scope:
-      path: ""
-      type: "guides"
     values:
       layout: "default"
 
-# Exclude from processing
 exclude:
   - Gemfile
   - Gemfile.lock
+  - README.md
   - node_modules
-  - vendor/bundle/
-  - vendor/cache/
-  - vendor/gems/
-  - vendor/ruby/
-
-# GitHub Pages settings
-github:
-  repository_name: open-bedrock-server
-  repository_url: https://github.com/teabranch/open-bedrock-server 
-
+  - vendor/

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -16,10 +16,6 @@ aux_links:
     - "https://github.com/teabranch/open-bedrock-server"
 aux_links_new_tab: true
 
-footer_content: >-
-  Open Bedrock Server — Licensed under
-  <a href="https://github.com/teabranch/open-bedrock-server/blob/main/LICENSE">MIT</a>.
-
 webmaster_verifications:
   google: SAWMasZ1hKCZm8hnk0xFUgqnFYYPgdrKG8jKuTJa6a0
 

--- a/docs/_includes/footer_custom.html
+++ b/docs/_includes/footer_custom.html
@@ -1,0 +1,5 @@
+<p class="text-small text-grey-dk-000 mb-0">
+  Open Bedrock Server is an open-source project licensed under
+  <a href="https://github.com/teabranch/open-bedrock-server/blob/main/LICENSE">MIT</a>.
+  Not affiliated with or endorsed by OpenAI or AWS.
+</p>

--- a/docs/_sass/color_schemes/anthropic.scss
+++ b/docs/_sass/color_schemes/anthropic.scss
@@ -1,0 +1,34 @@
+// Anthropic Cream Theme for just-the-docs
+// Warm, cream-like palette inspired by Anthropic/Claude branding
+
+// Page background
+$body-background-color: #FFFAF5;
+
+// Sidebar
+$sidebar-color: #F5EDE4;
+
+// Text colors
+$body-text-color: #1A1A1A;
+$body-heading-color: #2D2B27;
+
+// Links / accent
+$link-color: #D97706;
+
+// Code
+$code-background-color: #F5F0EB;
+
+// Borders
+$border-color: #E5DDD4;
+
+// Search
+$search-background-color: #FFF8F0;
+
+// Secondary text
+$base-button-color: #6B6560;
+
+// Navigation
+$nav-child-link-color: #1A1A1A;
+$sidebar-active-text-color: #D97706;
+
+// Feedback / buttons
+$btn-primary-color: #D97706;

--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -1,0 +1,16 @@
+// Override just-the-docs sidebar expansion formula at lg breakpoint.
+// The default formula absorbs leftover viewport space into the sidebar,
+// making it ~400-450px on laptops. This caps it at the base $nav-width.
+// Mobile dropdown behavior (below md breakpoint) is unaffected.
+
+.side-bar {
+  @media (min-width: 66.5rem) {
+    width: $nav-width;
+  }
+}
+
+.side-bar + .main {
+  @media (min-width: 66.5rem) {
+    margin-left: $nav-width;
+  }
+}

--- a/docs/guides/packaging.md
+++ b/docs/guides/packaging.md
@@ -1,3 +1,10 @@
+---
+title: Packaging
+parent: Guides
+nav_order: 6
+description: Guide for packaging and publishing to PyPI
+---
+
 # Packaging Guide for PyPI
 
 This guide outlines the steps to package the `open-bedrock-server` project and publish it to the Python Package Index (PyPI).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,44 +1,64 @@
 ---
-description: Open Bedrock Server Server - A unified, provider-agnostic chat completions API server
-layout: default
-nav_order: 1
-permalink: /
 title: Home
+nav_order: 0
+permalink: /
 ---
 
-# Open Bedrock Server Server
-
-{: .fs-9 }
+# Open Bedrock Server
 
 A unified, provider-agnostic chat completions API server supporting OpenAI and AWS Bedrock.
-{: .fs-6 .fw-300 }
 
-[Get started now](getting-started){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
-[View on GitHub](https://github.com/teabranch/open-bedrock-server){: .btn .fs-5 .mb-4 .mb-md-0 }
+<p><em>Find this useful? Star the repo to follow updates and show support!</em>
+<iframe src="https://ghbtns.com/github-btn.html?user=teabranch&repo=open-bedrock-server&type=star&count=true&size=large" frameborder="0" scrolling="0" width="170" height="30" title="Star on GitHub" style="vertical-align: middle;"></iframe></p>
+
+> **Install from PyPI** — `pip install open-bedrock-server` and run `bedrock-chat serve`.
+> See [CLI Reference](cli-reference) for all options.
 
 ---
 
-## 🚀 Quick Start
+## Quick Start
 
-### Installation & Setup
+### Installation
 
 ```bash
-# Clone and install
+# From PyPI
+pip install open-bedrock-server
+
+# Or from source
 git clone https://github.com/teabranch/open-bedrock-server.git
 cd open-bedrock-server
 uv pip install -e .
+```
 
-# Configure environment
+### Configure
+
+```bash
 bedrock-chat config set
+```
 
-# Start server
+Or set environment variables:
+
+```bash
+export OPENAI_API_KEY=sk-your-key
+export AWS_PROFILE=your-profile
+export API_KEY=your-server-auth-key
+```
+
+### Run
+
+```bash
 bedrock-chat serve --host 0.0.0.0 --port 8000
+```
+
+Verify:
+
+```bash
+curl http://localhost:8000/health
 ```
 
 ### Basic Usage
 
 ```bash
-# Test the unified endpoint
 curl -X POST http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer your-api-key" \
@@ -49,31 +69,9 @@ curl -X POST http://localhost:8000/v1/chat/completions \
   }'
 ```
 
-### File Query Example
-
-```bash
-# Upload a file
-curl -X POST http://localhost:8000/v1/files \
-  -H "Authorization: Bearer your-api-key" \
-  -F "file=@data.csv" \
-  -F "purpose=assistants"
-
-# Use file in chat completion
-curl -X POST http://localhost:8000/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer your-api-key" \
-  -d '{
-    "model": "gpt-4o-mini",
-    "messages": [{"role": "user", "content": "Analyze this data"}],
-    "file_ids": ["file-abc123def456"]
-  }'
-```
-
 ---
 
-## 🔄 Unified Endpoint
-
-### Single Endpoint for Everything
+## Unified Endpoint
 
 The `/v1/chat/completions` endpoint is the **only endpoint you need**. It:
 
@@ -81,65 +79,52 @@ The `/v1/chat/completions` endpoint is the **only endpoint you need**. It:
 2. **Routes** to the appropriate provider based on model ID
 3. **Converts** between formats as needed
 4. **Streams** responses in real-time when requested
-5. **Returns** responses in your preferred format
 
 ### Format Combinations
 
-All format combinations are supported through the unified endpoint:
-
 | Input Format | Output Format | Use Case | Streaming |
 |-------------|---------------|----------|-----------|
-| OpenAI | OpenAI | Standard OpenAI usage | ✅ |
-| OpenAI | Bedrock Claude | OpenAI clients → Bedrock response | ✅ |
-| OpenAI | Bedrock Titan | OpenAI clients → Titan response | ✅ |
-| Bedrock Claude | OpenAI | Bedrock clients → OpenAI response | ✅ |
-| Bedrock Claude | Bedrock Claude | Claude format preserved | ✅ |
-| Bedrock Titan | OpenAI | Titan clients → OpenAI response | ✅ |
-| Bedrock Titan | Bedrock Titan | Titan format preserved | ✅ |
+| OpenAI | OpenAI | Standard OpenAI usage | Yes |
+| OpenAI | Bedrock Claude | OpenAI clients to Bedrock response | Yes |
+| OpenAI | Bedrock Titan | OpenAI clients to Titan response | Yes |
+| Bedrock Claude | OpenAI | Bedrock clients to OpenAI response | Yes |
+| Bedrock Claude | Bedrock Claude | Claude format preserved | Yes |
+| Bedrock Titan | OpenAI | Titan clients to OpenAI response | Yes |
+| Bedrock Titan | Bedrock Titan | Titan format preserved | Yes |
 
 ---
 
-## 📚 Documentation
+## Documentation
 
-### Core Features
-- **[Getting Started](getting-started.md)** - Quick setup and basic usage
-- **[API Reference](api-reference.md)** - Complete API documentation
-- **[CLI Reference](cli-reference.md)** - Command-line interface guide
-
-### Advanced Features
-- **[Knowledge Bases (RAG)](KNOWLEDGE_BASES.md)** - 🧠 **NEW!** Bedrock Knowledge Bases integration for RAG
-- **[Files API](FILES_API.md)** - File upload and management capabilities
-
-### Development
-- **[Development Guide](development.md)** - Contributing and development setup
-- **[Testing](testing.md)** - Testing strategies and examples
-
-## 📚 Original Documentation
-
-### Core Documentation
+### Core
 
 - **[Getting Started](getting-started)** - Installation, setup, and first steps
 - **[API Reference](api-reference)** - Complete API documentation
-- __[Files API](files_api)__ - File upload, processing, and query system
 - **[CLI Reference](cli-reference)** - Command-line interface guide
-- **[Architecture](guides/architecture)** - System design and architecture
+
+### Advanced Features
+
+- **[Knowledge Bases (RAG)](knowledge_bases)** - Bedrock Knowledge Bases integration
+- **[Files API](FILES_API)** - File upload and management capabilities
 
 ### Guides
 
 - **[Usage Guide](guides/usage)** - Programming examples and use cases
 - **[AWS Authentication](guides/aws-authentication)** - AWS credential configuration
+- **[Architecture](guides/architecture)** - System design and architecture
 - **[Core Components](guides/core-components)** - Detailed component documentation
-- **[Testing](testing)** - Testing strategies and comprehensive test guide
-- **[Real API Testing](real-api-testing)** - Real API integration test documentation
+- **[Testing](guides/testing)** - Testing strategies and coverage
+- **[Packaging](guides/packaging)** - Building and distributing the package
 
 ### Development
 
 - **[Development Guide](development)** - Extending and customizing the server
-- **[Packaging Guide](guides/packaging)** - Building and distributing the package
+- **[Test Suite](testing)** - Test suite organization
+- **[Real API Testing](real-api-testing)** - Real API integration tests
 
 ---
 
-## 🎯 Key Features
+## Key Features
 
 ### Unified Interface
 
@@ -152,7 +137,7 @@ All format combinations are supported through the unified endpoint:
 
 - **File Upload**: Upload documents to S3 storage with OpenAI-compatible API
 - **Smart Processing**: Automatic content extraction from CSV, JSON, HTML, XML, Markdown, and text files
-- __Chat Integration__: Use `file_ids` parameter to include file content as context in conversations
+- **Chat Integration**: Use `file_ids` parameter to include file content as context in conversations
 - **File Management**: Complete CRUD operations for uploaded files
 
 ### Enterprise Ready
@@ -171,7 +156,7 @@ All format combinations are supported through the unified endpoint:
 
 ---
 
-## 🔗 Quick Links
+## Quick Links
 
 - **[GitHub Repository](https://github.com/teabranch/open-bedrock-server)**
 - **[Issues & Support](https://github.com/teabranch/open-bedrock-server/issues)**
@@ -180,6 +165,6 @@ All format combinations are supported through the unified endpoint:
 
 ---
 
-## 📄 License
+## License
 
 This project is licensed under the MIT License - see the [LICENSE](https://github.com/teabranch/open-bedrock-server/blob/main/LICENSE) file for details.

--- a/docs/knowledge_bases.md
+++ b/docs/knowledge_bases.md
@@ -1,3 +1,9 @@
+---
+title: Knowledge Bases
+nav_order: 10
+description: AWS Bedrock Knowledge Bases (RAG) integration
+---
+
 # Knowledge Bases (RAG) Integration
 
 This guide covers the integrated AWS Bedrock Knowledge Bases functionality in the Open Bedrock Server Server, providing Retrieval-Augmented Generation (RAG) capabilities.

--- a/docs/knowledge_bases.md
+++ b/docs/knowledge_bases.md
@@ -6,7 +6,7 @@ description: AWS Bedrock Knowledge Bases (RAG) integration
 
 # Knowledge Bases (RAG) Integration
 
-This guide covers the integrated AWS Bedrock Knowledge Bases functionality in the Open Bedrock Server Server, providing Retrieval-Augmented Generation (RAG) capabilities.
+This guide covers the integrated AWS Bedrock Knowledge Bases functionality in the Open Bedrock Server, providing Retrieval-Augmented Generation (RAG) capabilities.
 
 ## Overview
 

--- a/docs/real-api-testing.md
+++ b/docs/real-api-testing.md
@@ -1,3 +1,9 @@
+---
+title: Real API Testing
+nav_order: 8
+description: Real API integration tests with live credentials
+---
+
 # Real API Integration Tests
 
 This directory contains comprehensive integration tests that use real API credentials from your `.env` file to test the actual functionality of OpenAI and AWS Bedrock services.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,3 +1,9 @@
+---
+title: Testing
+nav_order: 7
+description: Test suite organization and CI/CD testing strategies
+---
+
 # Test Suite Organization
 
 This directory contains a comprehensive test suite organized for different CI/CD scenarios. The tests are carefully separated to ensure **safe CI execution** while still providing **real API validation**.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,5 +1,5 @@
 ---
-title: Testing
+title: Test Suite
 nav_order: 7
 description: Test suite organization and CI/CD testing strategies
 ---


### PR DESCRIPTION
## Summary
- Replaces `minima`/`github-pages` theme with `just-the-docs` + custom anthropic cream color scheme, matching the open-responses-server docs site
- Adds search, sidebar navigation with collapsible Guides section, and custom footer
- Adds YAML front matter to 5 pages that were missing it (testing, real-api-testing, FILES_API, knowledge_bases, guides/packaging)
- Consolidates duplicate documentation sections in index.md
- Updates GitHub Actions workflow for Ruby 3.3 and just-the-docs search init

## Test plan
- [ ] `cd docs && bundle install && bundle exec jekyll build` succeeds
- [ ] All 16 pages render in sidebar navigation
- [ ] Cream theme colors visible (warm background, amber accent links)
- [ ] Search works via sidebar button
- [ ] Guides section is collapsible with 6 child pages
- [ ] GitHub Pages deployment succeeds via workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude